### PR TITLE
Add a logback.xml resource

### DIFF
--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -1,0 +1,19 @@
+<configuration scan="true" scanPeriod="60 seconds">
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+    </filter>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <logger name="spa_skeleton" level="ALL" />
+  <logger name="io.pedestal" level="ALL" />
+  <logger name="org.eclipse" level="INFO"/>
+
+</configuration>


### PR DESCRIPTION
Suppresses the verbose org.eclipse TRACEs.
